### PR TITLE
Remove node_modules/bower_components from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,5 @@ xcuserdata
 *.xcodeproj
 Config/secrets/
 .DS_Store
-node_modules/
-bower_components/
 .swift-version
 CMakeLists.txt


### PR DESCRIPTION
Given that we use Vapor Cloud mostly and that doesn't support installing bower/npm modules ignoring these directories results in broken frontends.