### PR TITLE
Register S3Driver as NetworkDriver

### DIFF
--- a/Sources/App/Setup/configure.swift
+++ b/Sources/App/Setup/configure.swift
@@ -83,6 +83,6 @@ public func configure(
         // TODO: Remember to replace 'nodestemplate' with the name of the Vapor Cloud app.
         pathTemplate: "/nodestemplate/#mimeFolder/#uuid.#fileExtension"
     )
-    services.register(driver)
+    services.register(driver, as: NetworkDriver.self)
     Storage.cdnBaseURL = Sugar.env(EnvironmentKey.Storage.cdnPath, "http://127.0.0.1:8080")
 }


### PR DESCRIPTION
In configure.swift I had to change `services.register(driver)` to: `services.register(driver, as: NetworkDriver.self)`. Otherwise, when using `Storage.upload()`, it would complain that no `NetworkDriver` was registered.